### PR TITLE
Season 9 Rules via Google Docs

### DIFF
--- a/route/league.js
+++ b/route/league.js
@@ -92,15 +92,15 @@ router.get('/stats',function(req,res) {
   res.send(html);
 });
 
-router.get('/rules',function(req,res) {
-  const template = fs.readFileSync('./template/rules2.html').toString();
-  const html = mustache.render(base,{
-    title: 'Rules'
-  },{
-    content: template
-  });
-  res.send(html);
-});
+// router.get('/rules',function(req,res) {
+//   const template = fs.readFileSync('./template/rules3.html').toString();
+//   const html = mustache.render(base,{
+//     title: 'Rules'
+//   },{
+//     content: template
+//   });
+//   res.send(html);
+// });
 
 router.get('/new-teams',function(req,res) {
   const template = fs.readFileSync('./template/call-for-teams.html').toString();

--- a/template/base.html
+++ b/template/base.html
@@ -79,7 +79,8 @@ http://webdesignerwall.com/tutorials/css-responsive-navigation-menu
       <a class="dropdown-item" href="/stats">STATS</a>
       <a class="dropdown-item" href="/venues">VENUES</a>
       <a class="dropdown-item" href="/machines">MACHINES</a>
-      <a class="dropdown-item" href="/rules">RULES</a>
+      <!-- <a class="dropdown-item" href="/rules">RULES</a> -->
+      <a class="dropdown-item" href="https://docs.google.com/document/d/1NFfEDEAiFp470DArcyAQeTp4eFJ02fHLWYfaaxoowbc/edit?usp=sharing">RULES</a>
       <a class="dropdown-item" href="/signup">SIGN-UP</a>
       <a class="dropdown-item" href="/login{{#redirect_url}}?redirect_url={{.}}{{/redirect_url}}">LOGIN</a>
       <a class="dropdown-item" href="/profile">PROFILE</a>


### PR DESCRIPTION
This change would send users directly to the google doc that has been used to edit the changes. There are still some errors in that doc, outside the scope of this code base, at the moment. The exported HTML from that doc is also very twisted, and doesn't even render that well on mobile. Not sure why Google docs is not more friendly, but for now this is what we have.