### PR TITLE
Fixes for player pages (#13)

### DIFF
--- a/model/ifpa.js
+++ b/model/ifpa.js
@@ -96,6 +96,7 @@ module.exports = {
   //TODO: Q: Why does rank accept name instead of key?
   //      A: Because the key is not available all the time?
   rank: function(name) {
+    if(!name) return 0;
     var key = players.makeKey(name);
     var p = map[key];
     if(p) {

--- a/model/players.js
+++ b/model/players.js
@@ -65,8 +65,16 @@ console.log("No sugs file found: "+sname+ " Scanning players...");
 
 //TODO: load players from db? See hack at the bottom of the file.
 
+// HACK: This is a reverse hash for player keys.
+// TODO: This might possibly be insecure if we were relying on
+//       the 1 way nature of the hashing alg.
+const nameLookup = {};
+
 function makeKey(name) {
   var hash = util.digest(name.trim().toLowerCase());
+
+  nameLookup[hash] = name; // HACK
+
   return hash;
 }
 
@@ -110,9 +118,11 @@ console.log("sendVerify()... ");
 module.exports = {
   makeKey: makeKey,
   all: getAll,
-     //TODO: Should this involve a callback?
+  //TODO: Should this involve a callback?
   get: getPlayer,
-     //TODO: Change to use callback?
+  // TODO: getName is definitely kind of a hack, and illustrates how bad the old data system is.
+  getName: (key) => nameLookup[key] || 'MISSING KEY',
+   //TODO: Change to use callback?
   getByEmail: function(email) {
     if(!util.isEmail(email)) return;
     return this.getByField('email',email);

--- a/model/ratings.js
+++ b/model/ratings.js
@@ -11,5 +11,5 @@ const map = fs.readFileSync('data/IPR.csv').toString()
   }, {});
 
 module.exports = {
-  forName: name => map[name.trim().toLowerCase()]
+  forName: name => name ? map[name.trim().toLowerCase()] : 0
 };

--- a/route/league.js
+++ b/route/league.js
@@ -267,17 +267,19 @@ router.get('/players/:key',function(req,res) {
   // //TODO: Need something different than using players == users.
   // if(!p) { return res.redirect('/players'); }
 
+  const name = players.getName(req.params.key);
+
   //TODO: Might be nice to have team mapped.
   const st = stats.get(req.params.key);
   const html = mustache.render(base,{
     title: 'Player',
-    name: st.name,
+    name: name,
     num_matches: st.num_matches,
     points_won: st.points.won,
     ppm: st.ppm,
     pops: st.pops,
-    ifpa_rank: ifpa.rank(st.name),
-    ipr: IPR.forName(st.name.trim()) || 0,
+    ifpa_rank: ifpa.rank(name) || 'Unknown',
+    ipr: IPR.forName(name) || 'Unknown',
     history: st.history
   },{
     content: template


### PR DESCRIPTION
There are times when the stats might not exist for a player, and yet we were trying to access props of those stat objects. For now, there is a hack to keep a reverse cache to find player name by key. It's not super pretty, but this is the kind of thing that will be fixed in the new server code. So I'm ok making hacks like this when needed to keep the site working, and not displaying stack traces.