### PR TITLE
Season 9 Google Doc Rules

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -57,7 +57,7 @@
 <h2>Some Helpful Links</h2>
 <ul class="links">
 <li><b><a href="/signup">SIGN-UP HERE</a></b></li>
-<li><a href="/rules">League Rules</a></li>
+<li><a href="https://docs.google.com/document/d/1NFfEDEAiFp470DArcyAQeTp4eFJ02fHLWYfaaxoowbc/edit">League Rules</a></li>
 <li><b><a href="/MNP_HOWTO_venue_machines.mp4">How to add machines (Video)</a></b></li>
 <li><a href="/new-teams">Rules for Expansion Teams</a></li>
 <li><a href="http://facebook.com/SeattleMondayNightPinball">Monday Night Pinball on Facebook</a></li>


### PR DESCRIPTION
Fixes the old broken link. It may have been better to just have a 302 redirect on the old link until we fixed the template file, but there wasn't a nice way for people to author the rules and apply nice formatting at the same time.