### PR TITLE
Adding IPR column to /stats

### DIFF
--- a/route/league.js
+++ b/route/league.js
@@ -74,10 +74,12 @@ router.get('/stats',function(req,res) {
   const divs = all.reduce((divs, player) => {
     const pDivs = player.divisions;
     const { name, key } = player;
+    const rating = IPR.forName(name) || 0;
+
     Object.keys(pDivs).forEach(divId => {
       divs[divId] = divs[divId] || [];
       divs[divId].push(
-        Object.assign({}, pDivs[divId], { name, key })
+        Object.assign({}, pDivs[divId], { name, key, rating })
       );
 
       // NOTE: At node version 6.9.1, you can't use object spread operator
@@ -221,7 +223,7 @@ router.get('/teams/:team_id',function(req,res) {
   for(i in team.roster) {
     const p = team.roster[i];
 
-    const rating = IPR.forName(p.name.trim()) || 0;
+    const rating = IPR.forName(p.name) || 0;
     // TODO: Handle cases where rating == undefined, instead of default to 0.
     teamRating += parseInt(rating);
 

--- a/template/stats.html
+++ b/template/stats.html
@@ -11,6 +11,7 @@
   <thead class="thead-default">
     <tr class="header-row">
       <td>&nbsp;</td>
+      <td>IPR</td>
       <td>Player</td>
       <td># Matches</td>
       <td>PPM</td>
@@ -21,6 +22,11 @@
   {{#players}}
     <tr>
       <td class="text-xs-center">{{n}}</td>
+      <td class="text-xs-center">
+        {{#rating}}
+        <span class="badge badge-{{rating}}">{{rating}}</span>
+        {{/rating}}
+      </td>
       <td><a href="/players/{{key}}">{{name}}</a></td>
       <td class="text-xs-center">{{num_matches}}</td>
       <td>{{ppm}}</td>


### PR DESCRIPTION
Thanks to Adcock for all the work to normalize player names for the league, making it pretty easy to add IPR anywhere a player's (correct) name appears. This was a clear case where it can be pretty useful and interesting that did not already exist.