### PR TITLE
Fix for the missing team keys bug

### DIFF
--- a/model/matches.js
+++ b/model/matches.js
@@ -159,6 +159,7 @@ function isAuth(ukey,list) {
 
 function Team(params) {
   this.name = params.name;
+  this.key = params.key;
   this.captains = [
     params.captain,
     params.co_captain
@@ -1154,7 +1155,7 @@ function calcShared(scores) {
 }
 
 function countGames(match) {
-// console.log("countGames... for " +match.key);
+  // console.log("countGames... for " +match.key);
   var map = {};
   var incr = function(key) {
     var x = map[key] || 0;
@@ -1192,7 +1193,7 @@ function countGames(match) {
 }
 
 function roundDone(round) {
-//console.log("roundDone() round:",round);
+  //console.log("roundDone() round:",round);
   var games = round.games;
   var done = true;
   for(var i = 0; i < games.length; i++) {

--- a/util/fix-broken-matches.js
+++ b/util/fix-broken-matches.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const matches = require('../model/matches');
+
+matches.all().forEach(match => {
+  const { home, away, key } = match;
+  console.log(key);
+
+  // mnp-10-3-TWC-NLT
+  const [ak, hk] = key.split('-').slice(3);
+  home.key = home.key || hk;
+  away.key = away.key || ak;
+
+  
+
+
+  match.save();
+});
+
+// TODO: Do we want to "fix" any tie breakers? It seems like
+// some games might flip their win/loss if we don't do something.

--- a/util/spawn-matches.js
+++ b/util/spawn-matches.js
@@ -17,11 +17,15 @@ const season = require('../model/seasons').get();
 const matches = require('../model/matches');
 const Match = matches.Match;
 
+const pad = (num) => {
+  return num < 10 ? `0${num}` : `${num}`;
+};
+
 const getOrder = (date) => {
   const s = [
     date.getFullYear(),
-    date.getMonth() + 1,
-    date.getDate() + 1
+    pad(date.getMonth() + 1),
+    pad(date.getDate() + 1)
   ].join('');
   return parseInt(s);
 };
@@ -31,10 +35,10 @@ const time = getOrder(now);
 
 const current = season.weeks.find(week => {
   const date = getOrder(new Date(week.date));
-  console.log('week: ', date, week.date);
-  console.log('today:', time);
-  console.log('diff:', date - time);
-  if (date >= time && date - time < 7) {
+  console.log('week: ', week.n, date, week.date);
+  console.log('today:  ', time);
+  console.log('diff:  ', date - time);
+  if (date >= time) {
     return true;
   }
 });


### PR DESCRIPTION
One small detail that was missing from the new spawn script was the team keys, which were needed by standings to compute the totals. This should fix that issue, and I hope that there aren't any other major gaps from the old `gen-week` to the new `spawn-matches`.