### PR TITLE
Cleanup to continue live roster editing

### DIFF
--- a/route/league.js
+++ b/route/league.js
@@ -186,6 +186,33 @@ router.get('/players',function(req,res) {
   res.send(html);
 });
 
+router.get('/rosters.csv',function(req,res) {
+  // Get all the players on teams in the current season.
+  // TODO: Ideally, you could get rosters at any week of any season.
+  const {teams} = seasons.get();
+
+  res.type('text/csv');
+
+  res.send(
+    Object.keys(teams).reduce((list, tk) => {
+      return [
+        ...list,
+        ...teams[tk].roster.map(p => ([
+          p.name,
+          tk,
+          // Determine player role
+          teams[tk].captain === p.name ? 'C' :
+          teams[tk].co_captain === p.name ? 'A' :
+          'P',
+          // TODO: legacy playerdb.csv includes IFPA # and division
+        ].join(','))),
+      ];
+    }, [])
+    .sort()
+    .join('\n')
+  );
+});
+
 router.get('/players/:key',function(req,res) {
   const template = fs.readFileSync('./template/player.html').toString();
   // var p = players.get(req.params.key);

--- a/route/venues.js
+++ b/route/venues.js
@@ -87,6 +87,7 @@ const canEdit = (venue, user) => {
   const {teams} = seasons.get();
   let isHomeCaptain = false;
 
+  // TODO: Re-enable captain editing after updating machine picker.
   /*
   Object.keys(teams)
     .filter(tk => (teams[tk].venue === venue.key))
@@ -100,7 +101,7 @@ const canEdit = (venue, user) => {
       }
     });
   */
-  
+
   return isHomeCaptain;
 };
 

--- a/scripts/pre-week.sh
+++ b/scripts/pre-week.sh
@@ -10,21 +10,9 @@ LOG=/home/mnp/main/data/cronlog/pre-week.log
 
 echo "Running Pre week:" `date` >> $LOG
 
-cd /home/mnp/data-archive
-git checkout master
-git pull origin master
-
-# TODO Find a way to make the script not season hard coded.
-cp season-12/playerdb.csv ../main/data/season-12/playerdb.csv
+# Roster updates are now done through the site, and 
+# will be archived in the post-week script.
 
 cd /home/mnp/main
-
-# TODO: Consider a git pull for main.
-
-# Refresh the season.json
-# TODO season 12 is hard coded in the import season script.
-node importers/import-season.js
-
 node util/spawn-matches.js
-
 sh scripts/restart.sh


### PR DESCRIPTION
Now that we can edit rosters live on the site, we should not also be refreshing from github, because we might lose an edit if there are 2 sources of edits. That said, it would be nice to add the ability to output the playerdb.csv in order to keep an archive/backup in github in case anything goes wrong.